### PR TITLE
chore: upgrade GitHub Actions to Node.js 24 runtime

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,14 +10,14 @@ jobs:
         java: [ 25 ]
     name: Java ${{ matrix.java }} build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: liberica
           java-version: ${{ matrix.java }}
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
## GitHub Actions Node.js 24 Upgrade

Node.js 20 is being retired from GitHub-hosted runners:
- **Forced switch to Node.js 24**: June 2, 2026
- **Node.js 20 removal**: September 16, 2026

### Version Changes

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-java | v4 | v5 |
| actions/cache | v4 | v5 |

### Quality Gates

| Gate | Result |
|---|---|
| CI (Java 25 build) | PASSED |
| Node.js 20 deprecation warnings | RESOLVED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)