### PR TITLE
fix: remediate Snyk CVEs — Netty, Tomcat, Guava, httpclient (23/25 fixed)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,8 @@
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<maven.compiler.proc>full</maven.compiler.proc>
 		<vaadin.version>25.1.5</vaadin.version>
+		<netty.version>4.2.13.Final</netty.version>
+		<tomcat.version>11.0.22</tomcat.version>
 	</properties>
 
 	<dependencies>
@@ -243,6 +245,16 @@
 				<version>${vaadin.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>32.1.3-jre</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient</artifactId>
+				<version>4.5.13</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
## Summary

- Override `netty.version` to `4.2.13.Final` — resolves 11 Netty CVEs via Spring Boot property
- Override `tomcat.version` to `11.0.22` — resolves 7 Tomcat CVEs via Spring Boot property
- Force `com.google.guava:guava` to `32.1.3-jre` in `<dependencyManagement>` — resolves 3 Guava CVEs
- Force `org.apache.httpcomponents:httpclient` to `4.5.13` in `<dependencyManagement>` — resolves 1 httpclient CVE
- 2 findings remain unfixed (`commons-configuration:1.10`, `commons-lang:2.6`) — Snyk reports "No upgrade or patch available"; both are deep transitives through `eureka-client@2.0.5`

## CVE Remediation Table

| CVE / Snyk ID | Severity | Affected Package | Fixed Version | Fix Method |
|---|---|---|---|---|
| SNYK-JAVA-IONETTY-16425695 | Medium | `io.netty:netty-codec-http@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-IONETTY-16438737 | High | `io.netty:netty-codec-http@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-IONETTY-16438923 | High | `io.netty:netty-codec-http@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-IONETTY-16438926 | Medium | `io.netty:netty-codec-http@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-IONETTY-16438934 | High | `io.netty:netty-codec-http@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-IONETTY-16438323 | High | `io.netty:netty-codec-compression@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-IONETTY-16438931 | High | `io.netty:netty-codec-compression@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-IONETTY-16438929 | High | `io.netty:netty-codec-http2@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-IONETTY-16438935 | Medium | `io.netty:netty-handler-proxy@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-IONETTY-16438936 | High | `io.netty:netty-transport-classes-epoll@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-IONETTY-16438938 | High | `io.netty:netty-codec-dns@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-IONETTY-16438978 | High | `io.netty:netty-codec-http3@4.2.12.Final` | 4.2.13.Final | `<netty.version>` property override |
| SNYK-JAVA-ORGAPACHETOMCATEMBED-16643259 | High | `tomcat-embed-core@11.0.21` | 11.0.22 | `<tomcat.version>` property override |
| SNYK-JAVA-ORGAPACHETOMCATEMBED-16643276 | Medium | `tomcat-embed-core@11.0.21` | 11.0.22 | `<tomcat.version>` property override |
| SNYK-JAVA-ORGAPACHETOMCATEMBED-16690888 | Medium | `tomcat-embed-core@11.0.21` | 11.0.22 | `<tomcat.version>` property override |
| SNYK-JAVA-ORGAPACHETOMCATEMBED-16691220 | Medium | `tomcat-embed-core@11.0.21` | 11.0.22 | `<tomcat.version>` property override |
| SNYK-JAVA-ORGAPACHETOMCATEMBED-16691224 | Medium | `tomcat-embed-core@11.0.21` | 11.0.22 | `<tomcat.version>` property override |
| SNYK-JAVA-ORGAPACHETOMCATEMBED-16691231 | Critical | `tomcat-embed-core@11.0.21` | 11.0.22 | `<tomcat.version>` property override |
| SNYK-JAVA-ORGAPACHETOMCATEMBED-16643269 | Medium | `tomcat-embed-websocket@11.0.21` | 11.0.22 | `<tomcat.version>` property override |
| SNYK-JAVA-COMGOOGLEGUAVA-1015415 | Low | `com.google.guava:guava@14.0.1` | 32.1.3-jre | `<dependencyManagement>` forced override |
| SNYK-JAVA-COMGOOGLEGUAVA-32236 | Medium | `com.google.guava:guava@14.0.1` | 32.1.3-jre | `<dependencyManagement>` forced override |
| SNYK-JAVA-COMGOOGLEGUAVA-5710356 | Low | `com.google.guava:guava@14.0.1` | 32.1.3-jre | `<dependencyManagement>` forced override |
| SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-1048058 | Medium | `httpclient@4.5.3` | 4.5.13 | `<dependencyManagement>` forced override |
| SNYK-JAVA-COMMONSCONFIGURATION-10116124 | Medium | `commons-configuration@1.10` | — | **No fix available** (transitive via eureka-client@2.0.5) |
| SNYK-JAVA-COMMONSLANG-10734077 | High | `commons-lang:commons-lang@2.6` | — | **No fix available** (transitive via eureka-client@2.0.5) |

## Test plan

- [x] `./mvnw compile` passes with no errors
- [x] `npm audit` reports 0 vulnerabilities
- [x] `./mvnw dependency:tree` confirms `netty-codec-http:4.2.13.Final`, `tomcat-embed-core:11.0.22`, `guava:32.1.3-jre`, `httpclient:4.5.13`
- [x] `snyk test --file=pom.xml` reduced from 25 findings to 2 (both with no available patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)